### PR TITLE
English translation proof read and proposed changes. PDFs not yet generated from modified MD

### DIFF
--- a/manual-utatane/manual-en.md
+++ b/manual-utatane/manual-en.md
@@ -95,7 +95,7 @@ The Favor level between Sorai and Midorino is 1 at the end of setup. Player A ta
 
 Haila and Momozono are a couple with Favor level 2 and Discomfort level 3. The dice result to determine break up was 3 in the Couples Phase. They will usually break up because a dice result of 3 is less than or equal to the Discomfort level, but Haila has Attracted to reduce the effective Discomfort level by 1 to treat it as 2. So they do not break up and Discomfort level increases to 4. After this dice result in Kiss of Promise is 4. Usually, they will fail because (dice result 4) + (Favor level 2) - (Discomfort level 4) = 2 and this value is less than 4. But Haila and Momozono both have Cute to gain a bonus in Kiss or Promise and the final value becomes 4. Therefore, they succeed in the Kiss of Promise.
 
-Tsuge declares a Game of Love with the Murafuji-Momozono pair. Tsuge declared the Game of Love, and has Friendly. So she votes "Yes" 3 times. Murafuji also has Friendly but she is a part of target pair so she cannot use the effect of Friendly. One of the other girls votes "Yes" and three vote "No". As a result, 4 votes to "Yes" and 3 votes to "No" cause the Game of Love to pass.
+Tsuge starts a Game of Love with the Murafuji-Momozono pair. Tsuge started the Game of Love, and has Friendly. So she votes "Yes" 3 times. Murafuji also has Friendly but she is a part of target pair so she cannot use the effect of Friendly. One of the other girls votes "Yes" and three vote "No". As a result, 4 votes to "Yes" and 3 votes to "No" cause the Game of Love to pass.
 ```
 
 ## About five players game

--- a/manual-utatane/manual-en.md
+++ b/manual-utatane/manual-en.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-Yuri-Kure "Utsuroi" is an expansion set of Yuri-Kure. This expansion adds following elements to Yuri-Kure.
+Yuri-Kure "Utsuroi" is an expansion set of Yuri-Kure. This expansion adds the following elements to Yuri-Kure.
 
-- Orientation of the girls. Each girl has special attribute taking effect in the game.
-- Two additional girls for five players game. There are nine girls in five players game.
+- Orientation of the girls. Each girl has special attributes taking effect in the game.
+- Two additional girls for a five player game. There are nine girls in a five player game.
 
 This expansion also provides supplementary components for convenience.
 
@@ -13,103 +13,98 @@ This expansion also provides supplementary components for convenience.
 
 - Rule book (this paper)
 - Orientation tokens (8 kinds / 3 tokens for each Orientation)
-- Two girls token and cards
+- Two girl tokens and cards
 - Current action display marker
 - Vote tokens
-- Additional rule summary (same as provided in basic set)
-- Couple marker (same as provided in basic set)
+- Additional rule summary (same as provided in the basic set)
+- Couple Marker (same as provided in the basic set)
 
 ## The rule about Orientation
 
-When you play with "Orientation", add following rules to Yuri-Kure basic rule.
+When you play with "Orientation", add the following rules to the Yuri-Kure basic rules.
 
 ### Setup
 
-Assign Orientations to each girl in the setup phase. Girls will have TWO Orientations. One kind of Orientation cannot be held by more than three girls. For example, there is no game where four girls have Cute Orientation.
+Assign Orientations to each girl in the Setup Phase. Girls will each have TWO Orientations. One kind of Orientation cannot be held by more than three girls. For example, there is no game where four girls have the Cute Orientation.
 
-In the standard rule, assign Orientations as specified in this rule book. The list of specification is shown in "List of Orientations and effects" section. Girl's Orientations are also described on back of her card.
+When using the standard rules, assign Orientations as specified in this rule book. The list of Orientations is shown in "List of Orientations and effects" section. Girl's Orientations are also described on the back of her card.
 
-In the advanced rule, Orientations are assigned in the way agreed by players. It includes random assignment, discussion or any other way.
+When using the advanced rules, Orientations are assigned in a way agreed by the players. This could include random assignment, discussion, or any other method.
 
-### Additional phase: Game start phase
+### Additional phase: Game Start Phase
 
-After setup where before 1st turn begins, play Game start phase. Players have chance to reveal their Control points in this phase. Like revealing in Action phase, do Control point reveal step to each girl in the Action order.
+After setup before the 1st turn begins, play the Game Start Phase. Players have a chance to reveal their Control Points in this phase. Like revealing in the Action Phase, reveal Control Points to each girl in the Action Order.
 
-When reveal step finished at a girl having "Cool" Orientation, the player taking control declares a objective girl of ability to raise Favor level +3. If other players has more Control point over the girl, players may interrupt to reveal their Control point to change ability's objective.
+When the reveal step is finished for a girl having the "Cool" Orientation, the player with control declares a target girl to increase the Favor level with by 3. If other players have more hidden Control Points over the girl, players may interrupt to reveal their Control Points to change the target girl.
 
-When all Control point reveal step ends, advanced to 1st turn's Action phase. Game will progress same as basic game after this phase.
+When all Control Point reveal steps have ended, advance to the 1st turn Action Phase. The game will progress in the same way as the basic game after this phase.
 
 ![Orientation](img/seikou-en.png)
 
-### Changes about Support Point
+### Changes to Support Points
 
-Additional Support point will be modified below in a game with Orientation.
+Additional Support Points will be added in a game with Orientation.
 
-- +3 additional Support point after 3rd turn (+1 -> +3)
-- +5 additional Support point after 6th turn (+3 -> +5)
+- +3 additional Support Points after the 3rd turn (+1 -> +3)
+- +5 additional Support Points after the 6th turn (+3 -> +5)
 
-Important change from basic game: **Assigning Support point to a pair multiple time in Setup is forbidden.** It only restricts assignment in Setup phase. **Players can assign additional Support point in any combination, including duplicated assignment.**
+Important change from the basic game: **Assigning Support Points to a pair multiple times in setup is forbidden.** This only restricts assignment in the Setup Phase. **Players can assign additional Support Points in any combination, including duplicated assignment.**
 
 ```plaintext
-At the Setup: you cannot assign like "5 to Akane-Shirakaba, 4 to Akane-Shirakaba, 3 to Midorino-Tsuge, 2 to Midorino-Sorai, 1 to Murafuji-Tsuge" (Akane-Shirakaba is duplicated)
+During setup: you cannot assign "5 to Akane-Shirakaba, 4 to Akane-Shirakaba, 3 to Midorino-Tsuge, 2 to Midorino-Sorai, 1 to Murafuji-Tsuge" (Akane-Shirakaba is duplicated)
 
-When you assign "5 to Akane-Shirakaba, 4 to Sorai-Shirakaba, 3 to Midorino-Tsuge, 2 to Midorino-Sorai, 1 to Murafuji-Tsuge" at Setup, you can assign "2 to Sorai-Shirakaba, 1 to Midorino-Tsuge" at the end of the 3rd turn.
-
+When you assign "5 to Akane-Shirakaba, 4 to Sorai-Shirakaba, 3 to Midorino-Tsuge, 2 to Midorino-Sorai, 1 to Murafuji-Tsuge" during setup, you can assign "2 to Sorai-Shirakaba, 1 to Midorino-Tsuge" at the end of the 3rd turn.
 ```
 
-At the end of the game, the player assigned Support point most to the Fatal couple / Yuri-Polygamy group.
-(Additional Support point are also summarized.)
+At the end of the game, the player who assigned the most Support Points to the Fated Couple / Yuri Polygamy group is the winner. Additional Support Points are also included in winner determination.
 
-## List of Orientations and effects
+## List of Orientations and Effects
 
-Thought Orientation token has simplified Japanese text about effect, following list is formal effect text. When you have trouble with reading simplified text on tokens, read this list.
+The Orientation token has simplified Japanese text about the effect. The following list is formal effect text. If you cannot read the text on the tokens, use this list.
 
 - Aggressive - 大胆な告白 held by: Akane, Sorai
-  - When a girl having Aggressive does Confession and target girl chose No, result die roll is determined as if they have +2 extra Favor level.
+  - When a girl with Aggressive performs a Confession and the target girl chooses "No", the resulting dice roll is treated as if they have +2 extra Favor level.
 
 - Attracting - 惑わす魅力 held by: Shirakaba, Akane, Kuroki
-  - In Couple phase, a pair with a girl having Attracting becomes a couple in Favor level 5 (usually required Favor level 6.) Max Favor level is still 6. Attracting does not have duplicated effect even if both girl of a pair have Attracting.
+  - In the Couples Phase, a Girl Pair including a girl with Attracting becomes a couple at Favor level 5 (this usually requires Favor level 6.) The max Favor level is still 6. Attracting does not have a duplicated effect even if both girls of a pair have Attracting.
 
 - Cool - 怜悧な美人 held by: Sorai, Momozono
-  - Player taking control over this girl at Game start phase choose a pair with this girl and raise Favor level +3.
+  - A player taking control over this girl during the Game Start Phase chooses a pair with this girl and increases the Favor level by 3.
 
 - Passive - held by: Murafuji, Midorino
-  - この性向を持つ女の子が告白された時、告白をした女の子との間の好感度をその時点+1する。その後、通常の告白を受けた場合の処理の移る。(告白をされた場合、断っても断らなくても好感度+1。断った上でカップル非成立の場合、さらに好感度+1)
-  - When a girl having Passive is a target of Confession, raise Favor level +1 between confessing girl immediately. After Favor level raised, proceed to normal process of Confession. (Favor level raises +1 whichever this girl choses Yes or No. If this girl choses No and did not become a couple, raise Favor level +1 again.)
+  - When a girl with Passive is a target of Confession, raise the Favor level by 1 with the confessing girl immediately. After Favor level increases, proceed with the normal process of Confession. (Favor level increases by 1 whether the girl chooses "Yes" or "No". If this girl chooses "No" and a couple did not form, increase the Favor level by 1 again.)
 
 - Shy - 人見知り held by: Shirakaba, Midorino
-  - When a girl having Shy is a target of Approach and Favor level between approaching girl is 0, Favor level will be +3 instead of +1.
+  - When a girl with Shy is a target of Approach and the Favor level between them and the approaching girl is 0, Favor level will increase by 3 instead of 1.
 
 - Friendly - みんななかよし？ held by: Tsuge, Murafuji
-  - A girl having Friendly have 3 vote rights on Game of Love. (Voting to just one side, cannot split.)
+  - During a Game of Love, the vote of a girl with Friendly counts as 3 votes (all for the same choice, these votes cannot split.)
 
 - Cute - あふれる可愛げ held by: Kuroki, Haila, Momozono
-  - A couple will gain +1 bonus at Kiss of Promise for each Cute girls
+  - During a Kiss of Promise, add 1 to the dice roll result for each girl with Cute.
 
 - Attracted - 人を見つめる held by: Haila, Tsuge
-  - A couple will gain bonus at die roll in Couple's phase as if their Discomfort level is -1 for each Attracted girls. (Attracted does not affect breaking up by Discomfort level 6).
+  - During the Couples Phase, for each girl in the couple with Attracted, treat the Discomfort level as being 1 point lower during the dice roll only. (Minimum Discomfort of 0. Attracted does not affect breaking up at Discomfort level 6.)
 
 ```plaintext
 Examples to resolve effects:
 
-Akane(Aggressive/Attracting) did Confession to Murafuji(Friendly/Passive) when the Favor level is 1. Murafuji has Passive so Favor level between Akane-Murafuji raises +1 to become 2 when Akane's action is determined as Confession to Murafuji. Mufauji chose No then proceed to die roll. Die was 4. Usually die 4 will not make them couple because 4 is higher than their Favor level 2, but Akane has Aggressive so the Favor level is treated as 4 in this Confession, and die 4 is less or equal to the pseudo Favor level, it introduces Akane and Murafuji to be a couple.
+Akane (Aggressive/Attracting) confesses to Murafuji (Friendly/Passive) when the Favor level is 1. Murafuji has Passive so Favor level between Akane-Murafuji increases by 1 to become 2 when Akane's action is agreed to be a Confession to Murafuji. Mufauji chooses "No", then play proceeds to the dice roll. The result is 4. Usually, a result of 4 will not make them a couple because 4 is higher than their Favor level 2. But Akane has Aggressive so the Favor level is treated as 4 in this Confession. The dice result of 4 is less than or equal to the pseudo Favor level, so Akane and Murafuji become a couple.
 
-Favor level between Sorai and Midorino was 1 at the end of Setup. Player A took control of Sorai on Game start phse. Sorai has cool, so player A chose to raise Favor level between Midorino. Now Favor level between Sorai and Midorino is 4 at the beginning of 1st turn.
+The Favor level between Sorai and Midorino is 1 at the end of setup. Player A takes control of Sorai during the Game Start Phase. Sorai has Cool, so Player A chooses to raise Favor level between Sorai and Midorino. Now the Favor level between Sorai and Midorino is 4 at the beginning of the 1st turn.
 
-Haila and Momozono is a couple with Favor level 2 and Discomfort level 3. Die to determine break up was 3 in the Couple's phase. They will usually break up because die 3 is less or equal to the Discomfort level, but Haila has Attracted to reduce effect Discomfort level by 1 to treat the Discomfort level as 2, so they did not break up and Discomfort level raised to 3. After this die in Kiss of Promise was 4. Usually they will fail because (die 4) + (Favor level 2) - (Discomfort level 4) = 2 and this value is less than 4, but Haila and Momozono both have Cute to gain bonus in Kiss or Promise and the final value became 4. Finally they succeed to do Kiss or Promise.
+Haila and Momozono are a couple with Favor level 2 and Discomfort level 3. The dice result to determine break up was 3 in the Couples Phase. They will usually break up because a dice result of 3 is less than or equal to the Discomfort level, but Haila has Attracted to reduce the effective Discomfort level by 1 to treat it as 2. So they do not break up and Discomfort level increases to 4. After this dice result in Kiss of Promise is 4. Usually, they will fail because (dice result 4) + (Favor level 2) - (Discomfort level 4) = 2 and this value is less than 4. But Haila and Momozono both have Cute to gain a bonus in Kiss or Promise and the final value becomes 4. Therefore, they succeed in the Kiss of Promise.
 
-Tsuge did Game of Love to Murafuji-Momozono pair. Tsuge is the propose having Friendly so she voted Yes to 3 points. Murafuji also has Friendly but she is a part of target pair so she cannot take effect of Friendly. One of the other girl voted to yes and three voted to No. As a result, 4 votes to Yes and 3 votes to No made Game of Love passed.
+Tsuge declares a Game of Love with the Murafuji-Momozono pair. Tsuge declared the Game of Love, and has Friendly. So she votes "Yes" 3 times. Murafuji also has Friendly but she is a part of target pair so she cannot use the effect of Friendly. One of the other girls votes "Yes" and three vote "No". As a result, 4 votes to "Yes" and 3 votes to "No" cause the Game of Love to pass.
 ```
 
 ## About five players game
 
-When you play with five players, add Haila Ilmi and Momozono Renge to make nine girls game. Rules in five players are same with three or four players game except number of girls.
+When you play with five players, add Haila Ilmi and Momozono Renge to make a nine girl game. Rules in a five player game are the same as with a three or four player game, except the number of girls.
 
-
-## 点数計算アプリの紹介
 ## Introduction of Point calc app
 
-Point calculating web app is provided in follwoing URL. This app is best for mobile device (Android is recommended.)
+A point calculating web app is provided at the following URL. This app works best on mobile devices (Android is recommended.)
 ![QRコード](img/app-qr.png)　<https://yurikure.wr-inst.org/app>
 
 ## Credit
@@ -125,9 +120,9 @@ off-boxの皆さん　らっきょ　遊弋　風見白老人　土井ヴぃ　�
 ### Production and sale supported by
 王道エンターテイメント
 
-### Copyrihgt notice
+### Copyright notice
 
-This product uses following assets under MIT license.
+This product uses the following assets under an MIT license.
 
 <https://www.iconfinder.com/icons/211620/arrow_b_right_icon>
 

--- a/rule-src/rule-en.md
+++ b/rule-src/rule-en.md
@@ -49,8 +49,12 @@ Players write their Support Points on the Support Point Sheet **after the initia
 Each player chooses five Girl Pairs in secret, then writes down different 1 ~ 5 point values for the five Girl Pairs.
 These values are Support Points. Each value expresses how much the player pushes a Girl Pair.
 Higher values mean higher support for this Girl Pair.
-You must not use same value more than once, and the total Support Points will add up to 15.
-You may give the same Girl Pair Support Points more than once.
+You must not use the same value more than once, and the total Support Points will add up to 15.
+As an advanced rule, you may give the same Girl Pair Support Points more than once during setup. For example, if you give Akane-Sorai 5 Support Points, you may also give them 4 Support Points for a total of 9.
+
+```plaintext
+When playing for the first time, it is recommended to only allow Support Points to be given to the same Girl Pair once.
+```
 
 All Support Points decided here will be hidden until the game ends.
 
@@ -129,7 +133,7 @@ When you reveal your Control Points for a girl whose control has already been ta
 Example: Player A has 7 hidden Control Points over Murafuji. Nobody has revealed Control Points over Murafuji, so Player A reveals 1 Control Point to Murafuji and declares Murafuji will Approach Kuroki.
 Here, before the action is completed, Player B interrupts to reveal 2 Control Points to Murafuji, then declares her action will be a Confession to Midorino.
 Player A has more (hidden) Control Points over Murafuji, so he reveals 4 Control Points to Murafuji and declares Approach to Kuroki again.
-No other player reveals more Control Points for Murafuji, therefore Murafji's action is to Approach Kuroki.
+No other player reveals more Control Points for Murafuji, therefore Murafuji's action is to Approach Kuroki.
 
 ```plaintext
 Above is a simplified rule about revealing Control Points. More strict (but complex) rules are provided on our website. Applying strict rules is recommended if all players are expert.
@@ -158,7 +162,7 @@ Confession is declared along with a target girl.
    - The confessed to girl's choice is decided by the player who has control over her. Other players may interrupt to change the girl's choice by revealing their Control Points.
    - If no player reveals Control Points for the confessed to girl, the girl will choose "No".
 
-1. When the confessed to girl chooses "No", the result is determined by a roll of a dice.
+1. When the confessed to girl chooses "No", the result is determined by the roll of a dice.
    - If the rolled number is less than or equal to Favor level, this Girl Pair will become a couple (even though the confessed to girl said "No".)
    - If the rolled number is greater than the Favor level, they will not become a couple, and the Favor level increases by 1 between them.
 
@@ -173,7 +177,7 @@ A girl who is already part of a couple may be confessed to by other girls. This 
 
 #### Game of Love
 
-This action is a game of love, played by the girls. You need to declare a Game of Love along with the target Girl Pair. The target Girl Pair must not already be a couple (a girl in the target Girl's Pair may be part of a couple with another girl).
+This action is a Game of Love, played by the girls. You need to declare a Game of Love along with the target Girl Pair. The target Girl Pair must not already be a couple (a girl in the target Girl Pair may be part of a couple with another girl).
 
 The other girls with vote on whether the target Girl Pair should become a couple.
 

--- a/rule-src/rule-en.md
+++ b/rule-src/rule-en.md
@@ -2,17 +2,17 @@
 
 ## Story
 
-You will be an "Atmosphere" to introduce girls and couple your disired girls.
-Girls are first grade in a school. Watch the changing relations in 9 terms.
+You will be an "Atmosphere" to introduce and couple your desired girls.
+Girls are in the first grade in a school. Watch the changing relationships in 9 terms.
 
 ## Game overview
 
-In Yuri-Kure, you pursuit that desired Girls Pair will be the Fatal couple.
-Players assign Support Point to their desired Girls Pair in secret.
-Each player's Control Point of every girl will be introduced by assigned Support Point.
-You can gain control of girl's Action by **exposing your control points**.
-When your desired Girls Pair becomes Fatal couple, you are next to victory.
-Or Yuri Polygamy with three or more girls may also bring victory for players unsatisfied by a single girl-girl pair.
+In Yuri-Kure, your aim is that your desired Girl Pair will become the Fated Couple.
+Players assign Support Points to their desired Girl Pair in secret.
+Each player's Control Points of each girl will depend on their assigned Support Points.
+You can gain control of girl's Actions by **exposing your control points**.
+When your desired Girl Pair becomes a Fated Couple, you are close to victory.
+Or, Yuri Polygamy with three or more girls may also bring victory for players unsatisfied by a single girl-girl pair.
 
 ## Components
 
@@ -20,250 +20,253 @@ Or Yuri Polygamy with three or more girls may also bring victory for players uns
 
 ## Setup
 
-## Settle initial couple and initial Favors
+## Set up initial couple and initial Favors
 
-Settle following state of girls pair at random by any way, as such drawing two girl tokens.
+At the beginning of a game...
 
-At the beginning of game...
+1. A Girl Pair become a couple
+   - Place a Couple Marker between the Girl Pair, with the "Before Kiss of Promise" side (the blue side) faceup.
+1. A Girl Pair start with Favor Level 2
+1. Two Girl Pairs start with Favor Level 1
 
-1. A girls pair being a Couple
-   - Place a couple marker between coupled girls. "Before Kiss of Promise" side (blue one) should be shown here.
-1. A girls pair with Favor Level 2
-1. Two girls pairs with Favor Level 1
+Choose each of these Girl Pairs using a random method, such as drawing two face down girl tokens.
 
 Note:
 
-- Girls pair of 2 and 3 must be other pairs. No girls pair starting with Favor Level 3 or 4 by overlapping 2 and 3. And no game starting with two girls pairs having Favor Level 2.
-- 1 and (2 or 3) can be overlapped.
+- The same Girl Pair cannot receive starting Favor more than once. So Girl Pairs cannot start with Favor Level 3 or 4 by overlapping 2 and 3, or Favor Level 2 by gaining Favor Level 1 twice.
+- The starting couple may also receive a starting Favour increase.
 
-## Generate girls action order
+## Generate girls Action Order
 
-1st ~ 7th on the game board shows girls action order. Settle action order also at random any way, by placing girls token faced-down for example.
+1st ~ 7th on the game board shows the girls Action Order. Set up the Action Order randomly, by placing girls tokens face down for example.
 
-## Deciding players' Support Point
+## Deciding players' Support Points
 
-Players write their Support Points to Support Point Sheet **after initial game state is settled. You can refer initial game state when you decide Support Point.**
+Players write their Support Points on the Support Point Sheet **after the initial game state is settled. You can refer to the initial game state when you decide Support Points.**
 
 ### About Support Point assignment
 
-Each player chose five any girls pairs in secret, then write down each different 1 ~ 5 point values to the five girls pairs.
-These values are Support Points. Each value expresses how the player pushes a girls pair with assigned value.
-Higher value means the player pushes higher rate.
-You must not use same value more than one times, then total Support Point is always 15.
+Each player chooses five Girl Pairs in secret, then writes down different 1 ~ 5 point values for the five Girl Pairs.
+These values are Support Points. Each value expresses how much the player pushes a Girl Pair.
+Higher values mean higher support for this Girl Pair.
+You must not use same value more than once, and the total Support Points will add up to 15.
+You may give the same Girl Pair Support Points more than once.
 
 All Support Points decided here will be hidden until the game ends.
 
 ### Calculating Control Points
 
-Each players have their Control Points over every girl (Not a girls pair. Control Points exists per girl).
-You have possibility to control girl's Action by your Control Points.
-Control Points' values are introduced from each player's Support Point automatically.
-These values are calculated by following rule:
+Each player's Control Points effect the girls (not a Girl Pair, Control Points exist per girl).
+You are able to control the girl's Actions with your Control Points.
+Control Points are worked out from each player's Support Points automatically.
+These values are calculated by the following rule:
 
-#### Any girl's control point = Sum of Support Points' values where girls pair(s) including the girl
+#### Any girl's Control Points = Sum of Support Points for Girl Pairs including the girl
 
 ```plaintext
 Example:
-Player A assigned his support points to "Aakane / Shirakaba" by 3, "Shirakaba / Kuroki" by 2.
+Player A assigns 3 Support Points to "Aakane / Shirakaba", and 2 to "Shirakaba / Kuroki".
 Here,
-Control Point of Akane = 3
-Control Point of Shirakaba = 3 + 2 = 5
-Control Point of Kuroki = 2
+Control Points of Akane = 3
+Control Points of Shirakaba = 3 + 2 = 5
+Control Points of Kuroki = 2
 ```
 
 ```plaintext
-You can declare you have Control Point to a girl in Action Phase (described below). About Exposure of Control Point is explained in Turns and Action Phases.
+You can declare you have Control Points for a girl in the Action Phase (described below). Exposure of Control Points is explained in Turns and Action Phases.
 ```
 
 ### Additional Support Points
 
-Players gain additional Support Points in following times.
+Players gain additional Support Points at the following times.
 
-- 1 additional point at the end of 3rd turn
-- 3 additional point at the end of 6th turn
+- 1 additional point at the end of the 3rd turn
+- 3 additional points at the end of the 6th turn
 
-You can assign these points to any girls pairs as additional points, without any constraint as such you assigned to a girls pair in setup or not.
-You may assign 6th turn' additional points one by one. In other words, you can do all following assignment:
-3 points to a girls pair, 2 points to a girls pair and 1 point to a girls pair, 1 points to three different girls pair.
-**After Support Points added, Control Points also raises according to assigned Support Points.**
+You can assign these points to any Girl Pairs whether you supported them during setup, or not.
+You may assign 6th turn additional points one by one. In other words, you can do all the following assignments:
+3 points to a Girl Pair, 2 points to a Girl Pair and 1 point to another Girl Pair, 1 point each to three different Girl Pairs.
+**After Support Points are added, Control Points also increase according to assigned Support Points.**
 
 ## Turns
 
-"Turn" is a cycle of game progress. A turn contains following three phases.
+A "Turn" is a cycle of game progress. A turn contains the following three phases.
 
-1. Action phase
+1. Action Phase
 
-   - Girls do "Action (described below)" by action order in this phase.
+   - Girls perform an "Action" (described below) in the Action Order in this phase.
    - All interventions from players to girls are done in this phase.
 
-1. Couple's phase
+1. Couples Phase
 
-   - Processing occurrence about couples.
+   - Processing updates to the couples.
 
-1. Kiss of Promise phase
-   - Coupled girls pair try to kiss for promise here. Game end condition is also checked in this phase.
+1. Kiss of Promise Phase
 
-When game end condition is satisfied in "Kiss of Promise phase", the turn ends **immediately** and proceeds to winner determination.
+   - Coupled Girl Pairs attempt a Kiss of Promise. The game end condition is also checked in this phase.
+
+When the game end condition is satisfied in the Kiss of Promise Phase, the turn ends **immediately** and proceeds to winner determination.
 
 ```plaintext
-Immediate turn end may affect when Fatal couple and Yuri Polygamy are satisifed in same time.
+An immediate turn end may affect when Fated Couples and Yuri Polygamy are satisifed at the same time.
 ```
 
-Game longs 9 turns in max. When 9th turn ends the game proceeds to winner determination.
+The game lasts for up to 9 turns. When the 9th turn ends, the game proceeds to winner determination.
 
-## Action phase
+## Action Phase
 
-Each girl's action is determined in Action phase. Players can reveal their partial or all Control Point to choose girl's action.
-Girl's actions are determined in order of Action order. Action order is settled in setup.
-Action is one of these: "Approach", "Confession", "Game of Love", "Nothing".
+Each girl's action is determined in the Action Phase. Players can reveal some or all of their Control Points to choose a girl's action.
+Girl's actions are performed in the Action Order. Action Order is chosen in setup.
+Action is one of: "Approach", "Confession", "Game of Love", or "Nothing".
 
 ### Reveal of Control Points
 
-Players may reveal _partial_ or all control point about a target girl to gain control.
-You can reveal only equal or less value of your Control Point.
-You can reveal your control in any timing in Action phase.
-When you reveal your control point to a girl whose control has already been taken by other player, you need reveal more (NOT EQUAL) control point.
+Players may reveal _some_ or _all_ Control Points for a target girl to gain control.
+You can reveal up to the number of Control Points you have.
+You can reveal your control at any time in the Action Phase.
+When you reveal your Control Points for a girl whose control has already been taken by another player, you need reveal more (NOT EQUAL) Control Points.
 
-Example: Player A has 7 Control Point over Murafuji. Nobody has revealed control point to Murafuji, so Player A revealed 1 Control Point to Murafuji and declared Murafuji will do Approach to Kuroki.
-Here, before the action is determined Player B interrupted to reveal 2 Control Point to Murafuji then declared her action will be Confession to Midorino.
-Player A has more (hidden) control point over Murafuji, so he revealed 4 Control Point to Murafuji and declared Approach to Kuroki again.
-No other player revealed higher Control Point about Murafuji, therefore Murafji's action is determined to Approach to Kuroki.
+Example: Player A has 7 hidden Control Points over Murafuji. Nobody has revealed Control Points over Murafuji, so Player A reveals 1 Control Point to Murafuji and declares Murafuji will Approach Kuroki.
+Here, before the action is completed, Player B interrupts to reveal 2 Control Points to Murafuji, then declares her action will be a Confession to Midorino.
+Player A has more (hidden) Control Points over Murafuji, so he reveals 4 Control Points to Murafuji and declares Approach to Kuroki again.
+No other player reveals more Control Points for Murafuji, therefore Murafji's action is to Approach Kuroki.
 
 ```plaintext
-Above is simplified rule about revealing Control Points. More strict (but complex) rule is provided in our web site. Applying strict rule is recommended if all players are expert.
+Above is a simplified rule about revealing Control Points. More strict (but complex) rules are provided on our website. Applying strict rules is recommended if all players are expert.
 ```
 
 ### Actions
 
 #### Approach
 
-Approach raises Favor level between approaching girl and approached girl.
-Approach action is declared with target (approached) girl. Raise Favor level by 1 to the pair.
+Approach raises the Favor level between the approaching girl and the approached girl.
+The Approach action is declared, along with the target (approached) girl. Raise the Favor level by 1 for the pair.
 
-If approaching / approached girl is a part of coupled girls, and approaching to a girl other than the coupled girl / approached by a girl other than the coupled girl, raise Discomfort level by 1 to the pair(s).
+If the approaching / approached girl is part of a couple, and is approaching a girl other than the coupled girl / approached by a girl other than the coupled girl, raise Discomfort level by 1 for the pair(s).
 
-Favor level and Discomfort level are counted separately. For example, when Discomfort level raises to a pair having Favor level 4, Favor level will NOT be decrease to 3, but the pair will have BOTH Favor level 4 and Discomfort level 1.
+Favor level and Discomfort level are counted separately. For example, when the Discomfort level increases for a pair with Favor level 4, the Favor level will NOT be decreased to 3, but the pair will have BOTH Favor level 4 and Discomfort level 1.
 
-Favor levels and Discomfort levels are expressed by Favor/Discomfort tokens bridged between girls.
+Favor levels and Discomfort levels are expressed by Favor/Discomfort tokens placed between the girls.
 
 #### Confession
 
-Girl and girl becomes a couple in this action. **Only girl who is not a Couple to any other girl can do Confession.**
-Confession is declared with a target girl.
+Two girls become a couple in this action. **Only a girl who is not in a couple with any other girl can make a Confession.**
+Confession is declared along with a target girl.
 
-1. Confessed girl chooses "OK" to become a couple or "No". When a target girl chooses OK, confessing and confessed girls pair becomes a Couple then the action ends.
+1. The confessed to girl chooses "OK" to become a couple, or "No" to reject. When a target girl chooses "OK", the confessing and confessed to Girl Pair becomes a couple, then the action ends.
 
-   - Confessed girl's choice is decided by the player who has control over confessed girl. Other players may interrupt to change girl's choice by revealing their Control Point.
-   - If no player reveals Control Point to confessed girl, the girl will choose No.
+   - The confessed to girl's choice is decided by the player who has control over her. Other players may interrupt to change the girl's choice by revealing their Control Points.
+   - If no player reveals Control Points for the confessed to girl, the girl will choose "No".
 
-1. When confessed girl chooses No, result is determined by roll of die.
-   - If rolled number is less or equal to Favor level, these girls pair will be a couple (even though the confessed girl said No.)
-   - If rolled number is greater than Favor level, they will not be a couple and raise 1 Favor level between confessing / confessed girl.
+1. When the confessed to girl chooses "No", the result is determined by a roll of a dice.
+   - If the rolled number is less than or equal to Favor level, this Girl Pair will become a couple (even though the confessed to girl said "No".)
+   - If the rolled number is greater than the Favor level, they will not become a couple, and the Favor level increases by 1 between them.
 
-Whether confessed girl chooses OK or No, every girls pair of existing couple other than confessing / confessed girls pair raises 1 Discomfort level if a new couple is formed.
+Whether the confessed to girl chooses "OK" or "No", every couple the confessing / confessed to girls are a part of increase their Discomfort level by 1 if a new couple is formed.
 
-A newly formed couple is displayed by Couple marker's "Before Kiss of Promise" blue side.
-Even if a newly formed couple was once a couple with same girls pair before, they will start from "Before Kiss of Promise" again.
+If a new couple forms, place the Couple Marker between them with the "Before Kiss of Promise" side (the blue side) faceup.
+Even if a newly formed couple has been a couple before, they will start from "Before Kiss of Promise" again.
 
 ```plaintext
-A girl who is already a part of couple may be confessed from other girls. This may cause so-called two-timing.
+A girl who is already part of a couple may be confessed to by other girls. This may cause so-called two-timing.
 ```
 
 #### Game of Love
 
-This action is a game of love, played by girls. You need to declare Game of Love with target girls "pair". The target girls must not form a couple
-(it does not matter whether a girl of the target girls pair forms couple to other girl(s)).
-The target girls pair will be voted whether they should be a couple or not by other girls.
+This action is a game of love, played by the girls. You need to declare a Game of Love along with the target Girl Pair. The target Girl Pair must not already be a couple (a girl in the target Girl's Pair may be part of a couple with another girl).
 
-1. Other girls vote "Agree" or "Disagree" to the target girls pair.
+The other girls with vote on whether the target Girl Pair should become a couple.
+
+1. Other girls vote "Agree" or "Disagree" on the target Girl Pair.
    - Choice of vote is decided by the player who has control over the girl.
-   - When a girl is not taken control by any player, she will vote to Disagree.
-   - The girl who did Game of Love action here automatically vote to Agree.
+   - When a girl is not taken control of by any player, she will vote "Disagree".
+   - The girl who is making the Game of Love action automatically votes "Agree".
 
-Determinate girls voting in order of Action order. A next action order girl of the girl started Game of Love action votes first.
-When the last action order's girl votes, voting continues to 1st girl and all girls except voted girls will vote.
+Girls vote in the Action Order. The first girl to vote is the girl after the girl performing the Game of Love action, in the Action Order.
+When the last girl in the Action Order votes, voting continues to the 1st girl so that every girl (except the target Girl Pair) can vote.
 
-- Majority agree votes causes following effect. If Disagree is majority, nothing will happen.
-  1. Each target girl chooses they will be a couple or not. Choice is done in Action order.
-  1. If BOTH target girls chose OK to become a new couple, they will be a couple and causes same effects as formed couple in Confession.
-  1. If ONE OF target girls chose No to become a new couple, Discomfort level raises by 1 between these girls pair.
+- If a majority vote "Disagree", nothing will happen.
+- If a majority vote "Agree", the following will happen.
+  1. Each target girl chooses whether they will become a couple or not. This is done in Action Order.
+  1. If BOTH target girls chose "OK", they will become a couple, in the same way as during the Confession action.
+  1. If EITHER of the target girls chooses "No", Discomfort level increases by 1 between the target girls.
 
 #### Do nothing
 
-A girl ends action with no effect. If no player reveals Control Point to a girl, she will automatically choose Do Nothing.
+A girl takes no action. If no player reveals Control Points for a girl, she will automatically choose Do Nothing.
 
-When all girls end action, proceed to next phase.
+When all girls complete their action, proceed to the next phase.
 
-## Couple's phase
+## Couples Phase
 
-Roll dice to every couple. Effect is determined by score of "(Die number) - (Discomfort level)".
+Roll a dice for each couple. The effect is determined by the result of "(Dice number) - (Discomfort level)".
 
-- 0 or less: The couple breaks up (the girls pair will become not-a-couple state)
+- 0 or less: The couple breaks up (the Girl Pair will move to the not-a-couple state)
 - 1 ~ 2: Raise Discomfort level by 1
 - 3 or more: No effect
-- If die number is 6, do nothing above and raise Favor level by 1 (imagine critical).
+- If the dice number is 6, do not perform the above actions, and raise Favor level by 1.
 
 ```plaintext
-Die number 6 is exceptional case, not affected by score of "(Die number) - (Discomfort level)".
+Rolling 6 on the dice is an exceptional case, not affected by the score of "(Dice number) - (Discomfort level)".
 ```
 
-After above process, couples with Discomfort level 6 breaks up. Broken up girls pair's Favor and Discomfort level is reset to 0.
+After the above process, couples with Discomfort level 6 break up. Broken up Girl Pair's Favor and Discomfort level is reset to 0.
 
-Then each girls pair with Favor level 6 becomes a couple. This "natural forming" will not cause any raise of Discomfort level.
+Then, each Girl Pair with Favor level 6 become couples. This "natural forming" will not cause any increase of Discomfort level between themselves and any couples they are already a part of.
 
-## Kiss of Promise phase and victory condition
+## Kiss of Promise Phase and victory condition
 
-Roll die to every couple to successes Kiss of Promise or not. They will success when "(Die number) + (Favor level) - (Discomfort level)" is 4 or more.
+Roll a dice to determine whether each couple succeeds in the Kiss of Promise or not. They will succeed when "(Dice number) + (Favor level) - (Discomfort level)" is 4 or more.
 
-Initial couple (determined in setup) does not try it in 1st turn.
+The initial couple (determined in setup) does not try it in the 1st turn.
 
-A succeeded couple becomes "first time succeeded" state (expressed by red side of Couple marker). A failed couple becomes "Not succeeded" state (expressed by blue side of Couple marker).
-If a "first time succeeded" couple failed Kiss of Promise, the state will back to "Not succeeded".
+A succeeded couple moves to the "first time succeeded" state (expressed by the red side of the Couple Marker). A failed couple moves to the "Not succeeded" state (expressed by the blue side of the Couple Marker).
+If a "first time succeeded" couple fails the Kiss of Promise, the state will move back to "Not succeeded".
 
-If "first time succeeded" couple succeeded Kiss of Promise again in this turn, the couple will be Fatal Couple and the game ends.
-When multiple couples exists, all roll dice about Kiss of Promise are treated as same time. It means multiple Fatal Couples may be born in one game.
+If a "first time succeeded" couple succeeds the Kiss of Promise again, the couple will become a Fated Couple and the game ends.
+When multiple couples exist, all attempted Kiss of Promise are treated as simultaneous. This means multiple Fated Couples may be born in one game.
 
 ```plaintext
-Fatal couple needs to succeed Kiss of Promise in continuous 2 turns. Success, failure and then success cannot introduce to Fatal Couple.
+The Kiss of Promise must succeed for two consecutive turns for a couple to become a Fated Couple. Success, failure and then success does not cause a couple to become a Fated Couple.
 ```
 
-When Fatal Couple is born, winner is determined by sum of Support Point to Fatal Couple(s).
-If sum of Support Point tie-breaks, a player who revealed **LESS** Control Points about Fatal Couple(s) is winner.
-If revealed Control Points are also same, the game is draw.
+When a Fated Couple is born, the winner is determined by the sum of Support Points for the Fated Couple(s).
+If players have the same sum of Support Points, a player who revealed **FEWER** Control Points for the Fated Couple(s) is the winner.
+If revealed Control Points are also the same, the game is a draw.
 
 ```plaintext
-Example: Shirakaba and Midorino became a Fatal Couple. Player A and Player B both assigned 4 Support Points to Shirakaba-Midorino and they were max in the game.
-Player A has revealed 3 Control Point to Shirakaba and 4 Control Point to Midorino.
-Player B has revealed 1 Control Point to Shirakaba and 5 Control Point to Midorino.
-Sum of revealed Control Points is; A is 7, B is 6. It results winner is B.
+Example: Shirakaba and Midorino become a Fated Couple. Player A and Player B both assigned 4 Support Points to Shirakaba-Midorino and this is the highest number of Support Points for this couple.
+Player A has revealed 3 Control Points to Shirakaba and 4 Control Points to Midorino.
+Player B has revealed 1 Control Point to Shirakaba and 5 Control Points to Midorino.
+The sum of revealed Control Points is; A is 7, B is 6. So the winner is Player B.
 ```
 
-## Yuri Polygamy to end game
+## Yuri Polygamy to end the game
 
-When no Fatal Couple is born in Kiss of Promise phase, check Yuri Polygamy is formed or not. Yuri Polygamy means "In 3 ore more girls group, all girls pair in group is couple".
+When no Fated Couple is born in the Kiss of Promise Phase, check if Yuri Polygamy has formed. Yuri Polygamy means "In a group of 3 or more girls, all Girl Pairs in the group are couples".
 
 ```plaintext
 Example 1: When Akane and Shirakaba, Shirakaba and Kuroki, Kuroki and Akane are couples, Akane-Shirakaba-Kuroki's Yuri Polygamy is formed.
-Example 2: When Sorai and Midorino, Midorino and Tsuge are couples and Sorai and Tsuge is not a couple, Sorai-Midorino-Tsuge is not a Yuri Polygamy.
+Example 2: When Sorai and Midorino, Midorino and Tsuge are couples and Sorai and Tsuge are not a couple, Sorai-Midorino-Tsuge is not a Yuri Polygamy.
 Example 3: Murafuji and Akane, Murafuji and Kuroki, Murafuji and Shirakaba, Akane and Kuroki, Akane and Shirakaba, Kuroki and Shirakaba are couples, Murafuji-Akane-Kuroki-Shirakaba forms Yuri Polygamy.
 
-Note that already-coupled girl cannot confess to any other girl. Yuri Polygamy cannot be formed only by Confessions.
+Note that already-coupled girls cannot confess to any other girl. Yuri Polygamy cannot be formed only by Confessions.
 ```
 
-When Yuri Polygamy is formed, the game ends and proceed to determinate winner. Winner is determined by sum of Support Points assigned to girls pairs included in Yuri Polygamy group.
-Tie-break is also determined by revealed Control Points same as Fatal Couple's case. Less revealed player is winner.
+When Yuri Polygamy is formed, the game ends and proceeds to winner determination. The winner is determined by the sum of Support Points assigned to the Girl Pairs included in the Yuri Polygamy group.
+Tie-breaking is also determined by revealed Control Points, the same as in the Fated Couples case. The player with fewer revealed Control Points is the winner.
 
 ## Game end by 9th turn
 
-When both Fatal Couple and Yuri Polygamy is not born at the end of 9th turn, winner is determined by existing couple(s). Count Support Points (and Control Points to tie-break) same as Fatal Couple's case.
+When neither a Fated Couple nor Yuri Polygamy are born by the end of the 9th turn, the winner is determined by existing couple(s). Count Support Points (and Control Points to tie-break), the same as the Fated Couples case.
 
 ## Misc rules
 
 - Max Favor / Discomfort level is 6.
-- Favor level token or other components may short, actual game should not be affected by constraint from physical components.
+- If you are short of Favor level tokens or other components, continue the game as though you did have these components. The game should not be affected by constraints from physical components.
 
 ## FAQ
 
-- In 1st turn, another girls pair (not an initial couple settled in Setup) became a couple. Does this couple try Kiss of Promise in 1st turn?
+- In the 1st turn, another Girl Pair (not an initial couple settled in setup) become a couple. Does this couple try the Kiss of Promise in the 1st turn?
 
-  - Yes, they try. Only initial couple formed at Setup does not try Kiss of Promise in 1st turn. The initial couple also tries Kiss of Promise like other couples after 2nd turn.
+  - Yes, they try. Only the initial couple formed at setup does not try Kiss of Promise on the 1st turn. The initial couple also tries the Kiss of Promise like other couples after the 1st turn.


### PR DESCRIPTION
Please have a look over my pull request for the English rules translations. Let me know if you have questions or suggestions for improvement.

In rule-en.md, I added: You may give the same Girl Pair Support Points more than once.
This is because when I played, I wasn't sure if you were allowed to give the same girl group support points more than once (eg 5 for Tsuge and Marafuji, and 4 for Tsuge and Marafuji, for a total of 9.) Is this correct?

I suggest some changes for the image text:
components-en.png
- Game boards shows revealed Control Ponits of Player A~D -> Game board shows revealed Control Points of Player A~D
- Girls relation display area -> Girls relationship display area
  (This one is optional, I think it is clearer as "relationship")
- Tsuge(yellow) and Marafuji(purple) is a couple and has not successed Kiss of Promise -> Tsuge(yellow) and Marafuji(purple) are a couple and have not succeeded Kiss of Promise
- Couple Marker (successed Kiss of Promise once) -> Couple Marker (succeeded Kiss of Promise once)
- Couple marker Not successed Kiss of Promise yet -> Couple marker Not succeeded Kiss of Promise yet
- Faver level is 4, Discomfort level is 3. -> Favor level is 4, Discomfort level is 3.
- Faver level between Kuroki(black) and Sorai(sky blue) is 1. -> Favor level between Kuroki(Black) and Sorai(sky blue) is 1.

seikou-en.png
- Place TWO Orientation tokens under girl's cards. -> Place TWO Orientation tokens under the girl's cards.
- Two orientations must not be same one. -> The two Orientations must not be the same.

Thanks,
Tim